### PR TITLE
feat: use `ThisError` to simplify

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 bytesize = { workspace = true }
 dotenv = { workspace = true }
+thiserror = { workspace = true}
 
 # deps for ui
 eyre = "0.6.8"

--- a/ui/src/screen/example.rs
+++ b/ui/src/screen/example.rs
@@ -10,6 +10,7 @@ use iced::{
     widget::{button, column, text},
     Element, Length,
 };
+use thiserror::Error;
 
 use crate::sdk::vault::*;
 
@@ -37,11 +38,10 @@ pub enum ExampleScreenMessage {
 }
 
 /// Errors that can occur during the deployment of Counter.sol.
-#[derive(Debug, Clone)]
+#[derive(Debug, Error, Clone)]
 pub enum ExampleScreenError {
-    APIError,
-    ProviderConnectionError,
-    BlockSubscriptionError,
+    #[error("API Error")]
+    ProviderError(#[from] &'static ethers::providers::ProviderError),
 }
 
 /// Messages for this screen's internal use.
@@ -110,20 +110,5 @@ impl ExampleScreen {
         };
 
         content.into()
-    }
-}
-
-/// Converts the ProviderError into an ExampleScreenError.
-impl From<ethers::providers::ProviderError> for ExampleScreenError {
-    fn from(_error: ethers::providers::ProviderError) -> Self {
-        match _error {
-            ethers::providers::ProviderError::UnsupportedRPC => ExampleScreenError::APIError,
-            ethers::providers::ProviderError::JsonRpcClientError(_error) => {
-                println!("Error: {:#?}", _error);
-
-                ExampleScreenError::ProviderConnectionError
-            }
-            _ => ExampleScreenError::BlockSubscriptionError,
-        }
     }
 }


### PR DESCRIPTION
Just want to show you this @Alexangelj because `ThisError` makes building errors just so much easier. I think we should be using it all around the repo.