### PR TITLE
feat: dockerizing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,13 @@ anyhow.workspace = true
 clap = { version = "4.4.6", features = ["derive"] }
 tracing-subscriber.workspace = true
 dotenv.workspace = true
+toml = { version = "0.8.8", optional = true }
+
+# TCP communication
+hyper = { version = "0.14.10", features = ["full"], optional = true }
+
+[features]
+docker = ["hyper", "toml"]
 
 [dev-dependencies]
 # For book

--- a/simulation/src/lib.rs
+++ b/simulation/src/lib.rs
@@ -33,6 +33,8 @@ mod agents;
 #[allow(clippy::all)]
 #[rustfmt::skip]
 pub mod bindings;
+#[cfg(feature = "docker")]
+pub mod container;
 #[allow(unused)]
 mod math;
 #[allow(unused)]

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use simulation::settings::parameters::Multiple;
+use simulation::settings::SimulationConfig;
+use simulation::simulations::batch;
+
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use std::convert::Infallible;
+use toml;
+
+async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    let whole_body = hyper::body::to_bytes(req.into_body()).await.unwrap();
+    let toml_str = String::from_utf8(whole_body.to_vec()).unwrap();
+    let config: SimulationConfig<Multiple> = toml::from_str(&toml_str).unwrap();
+
+    // Now you can use the deserialized TOML data
+    println!("Received config: {:?}", config);
+
+    Ok(Response::new(Body::from("Received TOML data")))
+}
+
+pub async fn run() {
+    let make_svc =
+        make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle_request)) });
+
+    let addr = ([127, 0, 0, 1], 3000).into();
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    if let Err(e) = server.await {
+        eprintln!("server error: {}", e);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,10 @@ use clap::{ArgAction, CommandFactory, Parser, Subcommand};
 use dotenv::dotenv;
 use simulation::simulations;
 use ui as interface;
+#[cfg(feature = "docker")]
+pub mod container;
 
+#[cfg(not(feature = "docker"))]
 /// Represents command-line arguments passed to the `Arbiter` tool.
 #[derive(Parser)]
 #[clap(name = "Excalibur")]
@@ -22,6 +25,7 @@ struct Args {
     verbose: Option<u8>,
 }
 
+#[cfg(not(feature = "docker"))]
 /// Defines available subcommands for the `Arbiter` tool.
 #[derive(Subcommand)]
 enum Commands {
@@ -37,6 +41,7 @@ enum Commands {
     },
 }
 
+#[cfg(not(feature = "docker"))]
 fn main() -> Result<()> {
     dotenv().ok();
 
@@ -84,5 +89,12 @@ fn main() -> Result<()> {
         },
         None => Args::command().print_long_help()?,
     }
+    Ok(())
+}
+
+#[cfg(feature = "docker")]
+#[tokio::main]
+async fn main() -> Result<()> {
+    container::run().await;
     Ok(())
 }


### PR DESCRIPTION
- [x] Can run a server locally and receive config via the port.
To try this run:
```bash
cargo run --features docker
```
which starts the listener on 3000. Then you can do something like this:
```bash
curl -X POST -H "Content-Type: application/octet-stream" --data-binary @configs/dca/static.toml  http://localhost:3000
```
You will see that the server received the data in this terminal, and in your terminal where the server is running, you will get an output that displays the parsed `SimulationConfig<Multiple>` for you

- [ ] Run simulation with the batcher.
- [ ] Create docker file for something like this.
- [ ] Edit UI to have feature flags for comms into this server.