### PR TITLE
added default rpc

### DIFF
--- a/crates/app/src/controller/settings/rpc.rs
+++ b/crates/app/src/controller/settings/rpc.rs
@@ -24,7 +24,6 @@ impl From<anyhow::Error> for Feedback {
     }
 }
 
-
 #[derive(Debug, Clone, Default)]
 pub enum Message {
     #[default]
@@ -73,7 +72,9 @@ pub struct RpcManagement {
 impl RpcManagement {
     pub fn new(mut storage: RPCList) -> Self {
         if storage.chains.get("flashbot").is_none() {
-            storage.chains.insert("flashbot".to_owned(), RPCValue::default());
+            storage
+                .chains
+                .insert("flashbot".to_owned(), RPCValue::default());
         }
         Self {
             storage,
@@ -116,7 +117,7 @@ impl RpcManagement {
     #[allow(dead_code)]
     pub fn view_rpcs(&self) -> Element<'_, Message> {
         let mut content = Column::new();
-
+        tracing::debug!("Chain packet: {:?}", self.storage.list());
         // List all the rpcs from the RPC storage
         for chain_packet in self.storage.list() {
             let mut row = Row::new().spacing(Sizes::Md);
@@ -195,11 +196,6 @@ impl State for RpcManagement {
         match message {
             Message::Sync(storage) => {
                 tracing::debug!("Syncing RPCs in rpc settings: {:?}", storage.clone());
-                // let mut storage = storage.clone();
-                // if let Ok(chain_packet) = self.get_chain_packet() {
-                //     let chain_packet_name = chain_packet.name.clone();
-                //     storage.chains.insert(chain_packet_name, chain_packet);
-                // }
                 self.storage = storage;
             }
             Message::ChangeName(name) => {
@@ -235,6 +231,11 @@ impl State for RpcManagement {
             }
             Message::Submit => {
                 tracing::debug!("Submitting RPC");
+                let mut storage = self.storage.clone();
+                if let Ok(chain_packet) = self.get_chain_packet() {
+                    let chain_packet_name = chain_packet.name.clone();
+                    storage.chains.insert(chain_packet_name, chain_packet);
+                }
                 self.reset();
             }
             Message::Delete => {

--- a/crates/app/src/controller/settings/rpc.rs
+++ b/crates/app/src/controller/settings/rpc.rs
@@ -24,6 +24,7 @@ impl From<anyhow::Error> for Feedback {
     }
 }
 
+
 #[derive(Debug, Clone, Default)]
 pub enum Message {
     #[default]
@@ -70,7 +71,10 @@ pub struct RpcManagement {
 }
 
 impl RpcManagement {
-    pub fn new(storage: RPCList) -> Self {
+    pub fn new(mut storage: RPCList) -> Self {
+        if storage.chains.get("flashbot").is_none() {
+            storage.chains.insert("flashbot".to_owned(), RPCValue::default());
+        }
         Self {
             storage,
             chain_packet: None,
@@ -191,6 +195,11 @@ impl State for RpcManagement {
         match message {
             Message::Sync(storage) => {
                 tracing::debug!("Syncing RPCs in rpc settings: {:?}", storage.clone());
+                // let mut storage = storage.clone();
+                // if let Ok(chain_packet) = self.get_chain_packet() {
+                //     let chain_packet_name = chain_packet.name.clone();
+                //     storage.chains.insert(chain_packet_name, chain_packet);
+                // }
                 self.storage = storage;
             }
             Message::ChangeName(name) => {

--- a/crates/app/src/model/rpcs/mod.rs
+++ b/crates/app/src/model/rpcs/mod.rs
@@ -14,6 +14,16 @@ pub struct RPCValue {
     pub url: String,
 }
 
+impl Default for RPCValue {
+    fn default() -> Self {
+        Self {
+            chain_id: 1,
+            name: "Flashbots".to_string(),
+            url: "rpc.flashbots.net".to_string(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct RPCList {
     pub chains: HashMap<String, RPCValue>,


### PR DESCRIPTION
Closes #263 

Strange behavior:

- When adding a new RPC, the view of the rpc table overwrites the first rpc. 
- Right now this is the default main-net RPC

The desired behavior would be that when an RPC is added, the new rpc doesn't overwrite the view but is just appended to the view. 

Also when we delete any rpc (one or many) the view completely empties when it should maintain rpcs that aren't deleted. 

